### PR TITLE
Add Layer::compute_size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [Unreleased]
+### Added
+* Add `Layer::compute_size()`
 
 ## [0.8.0] - 2023-01-28
 ### Added

--- a/src/tile.rs
+++ b/src/tile.rs
@@ -223,6 +223,11 @@ impl Layer {
         }
     }
 
+    /// Compute the encoded size in bytes.
+    pub fn compute_size(&self) -> usize {
+        self.layer.compute_size() as usize
+    }
+
     /// Get position of a key in the layer keys.  If the key is not found, it
     /// is added as the last key.
     fn key_pos(&mut self, key: &str) -> usize {


### PR DESCRIPTION
I'm working on https://github.com/Urban-Analytics-Technology-Platform/od2net/tree/tippecanwho/tippe, an experiment to generate pmtiles in Rust. To limit by tile size as I add in features, I need to check the layer's size before adding the layer to a tile.