### PR TITLE
encoder: fix missing segment after redundant point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [Unreleased]
+### Changed
+* Fix skipped first line segment in multilinestrings when initial point is redundant
 
 ## [0.10.0] - 2025-03-15
 ### Changed


### PR DESCRIPTION
When encoding a point that is identical to a previous point, that point is currently entirely skipped, as it is considered redundant.

However, this means that if in a multilinestring,
the first point of a line is identical to the last point of the previous line, the second point of that line will be treated as the first. Thus the segment from the end of the previous line to the second point of the current line is not encoded.

This PR adds a flag to detect this case (in both multilinestring and multipolygons), still skip the redundant MoveTo command,
but convert the moveTo command to the second point to a lineTo command.

It also adds a test for this behavior as well as other forms of redundant points.

If you are curious, here is a real life usage case, that warranted this PR : https://github.com/OpenRailAssociation/osrd/issues/10221

Also, thanks for writing this lib! 