### PR TITLE
encoder: simplify initial point redundancy logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+* Simplify the initial point redundancy handling logic
+
 ## [0.10.2] - 2025-06-25
 ### Changed
 * Fix skipped first line segment in multilinestrings when initial point is

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -109,9 +109,6 @@ where
 
     /// Encoded geometry data
     data: Vec<u32>,
-
-    /// Flag turning the initial move to into a line to
-    line_to_first_point: bool,
 }
 
 /// Validated geometry data for [Feature](struct.Feature.html)s.
@@ -188,7 +185,6 @@ where
             x_max: i32::MAX,
             y_min: i32::MIN,
             y_max: i32::MAX,
-            line_to_first_point: false,
             ..Default::default()
         }
     }
@@ -299,8 +295,8 @@ where
             if pt.0 == px && pt.1 == py {
                 if self.count == 0 {
                     // If the first point of a line in a multilinestring (or multipolygon) is the same as the last of the previous line,
-                    // we skip the MoveTo command and set a flag so the next point gets a LineTo instead.
-                    self.line_to_first_point = true
+                    // we skip the MoveTo command and increase the count so the next point correctly gets a LineTo.
+                    self.count += 1;
                 } else {
                     // Redundant points other than the first are unexpected, and entirely skipped.
                     log::trace!("redundant point: {px},{py}");
@@ -314,23 +310,18 @@ where
                     self.push_command(Command::MoveTo);
                 }
             }
-            GeomType::Linestring => {
-                match (self.count, self.line_to_first_point) {
-                    (0, false) => self.push_command(Command::MoveTo),
-                    (1, _) | (0, true) => self.push_command(Command::LineTo),
-                    _ => (),
-                }
-            }
+            GeomType::Linestring => match self.count {
+                0 => self.push_command(Command::MoveTo),
+                1 => self.push_command(Command::LineTo),
+                _ => (),
+            },
             GeomType::Polygon => {
-                match (self.count, self.line_to_first_point) {
-                    (0, false) => self.push_command(Command::MoveTo),
-                    (1, _) | (0, true) => self.push_command(Command::LineTo),
+                match self.count {
+                    0 => self.push_command(Command::MoveTo),
+                    1 => self.push_command(Command::LineTo),
                     _ => (),
                 }
-                if (self.count >= 2
-                    || (self.count == 1 && self.line_to_first_point))
-                    && self.should_simplify_point(pt.0, pt.1)
-                {
+                if self.count >= 2 && self.should_simplify_point(pt.0, pt.1) {
                     self.pop_point();
                 }
             }
@@ -388,7 +379,6 @@ where
         self.count = 0;
         self.xy_end = None;
         self.pt0 = None;
-        self.line_to_first_point = false;
         Ok(())
     }
 
@@ -503,7 +493,7 @@ mod test {
     }
 
     #[test]
-    fn test_multilinestring_skips_redundant_first_point() {
+    fn test_multilinestring_with_redundant_points() {
         let v = GeomEncoder::new(GeomType::Linestring)
             .point(2.0, 2.0)
             .unwrap()
@@ -517,10 +507,21 @@ mod test {
             .unwrap()
             .point(13.0, 15.0)
             .unwrap()
+            .point(10.0, 10.0)
+            .unwrap()
+            .complete()
+            .unwrap()
+            .point(2.0, 2.0)
+            .unwrap()
+            .point(10.0, 10.0)
+            .unwrap()
             .encode()
             .unwrap()
             .into_vec();
-        assert_eq!(v, vec!(9, 4, 4, 10, 16, 16, 10, 6, 10));
+        assert_eq!(
+            v,
+            vec!(9, 4, 4, 10, 16, 16, 18, 6, 10, 5, 9, 9, 15, 15, 10, 16, 16)
+        );
     }
 
     #[test]


### PR DESCRIPTION
The line_to_initial_point flag was in fact unnecessary.
Its behavior could be replicated by simply increasing the count by one without adding a point.

I thought doing so would mess up the command count, but in fact since set_command_count already expects the count to be off by one, everything works out perfectly!

Additionally a redundant lineto command could be added by the previous fix, which is fixed.

The test_multilinestring_with_redundant_points test was strengthened to catch more edge cases, including the above.

There is still one redundancy in the test output, with 2 lineto commands following each other. But since `complete` was explicitly called by the user between these 2 commands, it seems to me that this redundancy should be the expected behavior.

Sorry for not getting the pr quite right the first time '^^