### PR TITLE
Check duplicated feature ID only when debug_assertion flag is set

### DIFF
--- a/src/tile.rs
+++ b/src/tile.rs
@@ -269,11 +269,13 @@ impl Feature {
     /// Set the feature ID.
     pub fn set_id(&mut self, id: u64) {
         let layer = &self.layer.layer;
-        if layer.features.iter().any(|f| f.id == Some(id)) {
-            log::warn!(
-                "Duplicate feature ID ({id}) in layer {:?}",
-                &layer.name
-            );
+        if cfg!(debug_assertions) {
+            if layer.features.iter().any(|f| f.id == Some(id)) {
+                log::warn!(
+                    "Duplicate feature ID ({id}) in layer {:?}",
+                    &layer.name
+                );
+            }
         }
         self.feature.id = Some(id);
     }


### PR DESCRIPTION
When there is a lot of features (maybe too much in my project), this check takes a lot of time even in release mode

This is speeding up my whole project from 1min19 to 1min03 (not confidential, I can share it here if you want to take a look)

I don't know if people are always using `cargo run --release` or not but if it's the case, this is equivalent to `if false {}`, it may be better to use a HashSet (that is slower than my proposition but faster than current state) or use a `validate-data` feature (that can be used for other checks)

I think that this is the best solution, if you want me to try something else, I can try